### PR TITLE
Integrate some part of fractal demos

### DIFF
--- a/demos/Dockerfile.demos
+++ b/demos/Dockerfile.demos
@@ -10,16 +10,10 @@ RUN apt-get -y install git
 # Install fractal-client
 RUN pip install fractal-client==1.3.4a1
 
-# Clone fractal-demos
-RUN git clone https://github.com/fractal-analytics-platform/fractal-demos.git /home/fractal-share/fractal-demos
-CMD pwd && ls -lash && ls -lash /home/fractal-share/ && ls -lash /home/fractal-share/fractal-demos
+COPY demos/fractal.env ./.fractal.env
+COPY demos/run_all_demos.sh ./run_all_demos.sh
 
-# COPY demos/fractal.env /home/fractal-share/fractal-demos/examples/.fractal.env
-# COPY demos/example_01.sh /home/fractal-share/fractal-demos/examples/example_01.sh
-
-# WORKDIR /home/fractal-share/fractal-demos/examples/
-# RUN pip install zenodo-get
-# RUN mkdir -p ../images
+RUN pip install zenodo-get
 
 # launch command
-# CMD echo "START 01" && pwd && ls -lash && bash example_01.sh && echo "END 01"
+CMD echo "START ALL" && pwd && ls -lash && bash run_all_demos.sh && echo "END ALL"

--- a/demos/Dockerfile.demos
+++ b/demos/Dockerfile.demos
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+
+# Select Python image
+FROM python:3.11-slim
+
+# Install git
+RUN apt-get update
+RUN apt-get -y install git
+
+# Install fractal-client
+RUN pip install fractal-client==1.3.4a1
+
+# Clone fractal-demos
+RUN git clone https://github.com/fractal-analytics-platform/fractal-demos.git /home/fractal-share/fractal-demos
+CMD pwd && ls -lash && ls -lash /home/fractal-share/ && ls -lash /home/fractal-share/fractal-demos
+
+# COPY demos/fractal.env /home/fractal-share/fractal-demos/examples/.fractal.env
+# COPY demos/example_01.sh /home/fractal-share/fractal-demos/examples/example_01.sh
+
+# WORKDIR /home/fractal-share/fractal-demos/examples/
+# RUN pip install zenodo-get
+# RUN mkdir -p ../images
+
+# launch command
+# CMD echo "START 01" && pwd && ls -lash && bash example_01.sh && echo "END 01"

--- a/demos/example_01.sh
+++ b/demos/example_01.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd 01_cardio_tiny_dataset
+cp ../.fractal.env .
+./fetch_test_data_from_zenodo.sh
+./run_example.sh

--- a/demos/fractal.env
+++ b/demos/fractal.env
@@ -1,0 +1,5 @@
+FRACTAL_SERVER=http://fractal-server:8000
+FRACTAL_USER=admin@fractal.xy
+FRACTAL_PASSWORD=1234
+
+

--- a/demos/run_all_demos.sh
+++ b/demos/run_all_demos.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+
+# I AM IN /home/fractal-share
+
+git clone https://github.com/fractal-analytics-platform/fractal-demos.git
+
+cd fractal-demos/examples
+cp ../../.fractal.env .
+
+# Run example 01
+echo "RUN EXAMPLE 01 - START"
+cd 01_cardio_tiny_dataset
+mkdir -p ../images
+cp ../.fractal.env .
+./fetch_test_data_from_zenodo.sh
+./run_example.sh
+cd ..
+echo "RUN EXAMPLE 01 - END"
+
+# Run example 02
+# ...
+
+echo "ALL GOOD"
+

--- a/demos/run_all_demos.sh
+++ b/demos/run_all_demos.sh
@@ -1,12 +1,25 @@
 #!/bin/bash
 
 
-# I AM IN /home/fractal-share
+cp -v .fractal.env /home/fractal-share/
+cd /home/fractal-share
+pwd
 
 git clone https://github.com/fractal-analytics-platform/fractal-demos.git
 
 cd fractal-demos/examples
-cp ../../.fractal.env .
+pwd
+cp -v ../../.fractal.env .
+
+# Trigger task collection
+fractal task collect fractal-tasks-core --package-version 0.11.0 --package-extras fractal-tasks
+
+# Wait for the end of task collection
+while [ "$(fractal task list)" == "[]" ]; do
+    echo "No task available, wait 10 seconds.";
+    sleep 10;
+done
+fractal task list
 
 # Run example 01
 echo "RUN EXAMPLE 01 - START"

--- a/docker-compose-demos.yml
+++ b/docker-compose-demos.yml
@@ -48,6 +48,7 @@ services:
       timeout: 2s
       retries: 5
 
+
   client:
     container_name: fractal-client
     depends_on:
@@ -59,3 +60,15 @@ services:
       dockerfile: client/Dockerfile.client
     ports:
       - 5173:5173
+
+  demos:
+    container_name: fractal-demos
+    depends_on:
+      server:
+        condition: service_healthy
+    image: fractal-demos
+    build:
+      context: .
+      dockerfile: demos/Dockerfile.demos
+    volumes:
+      - ./fractal-share/:/home/fractal-share/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       # => errors if the server connects before the stop
       # this checks if the system is ready
       test: pg_isready -p 5433
-      interval: 1s
+      interval: 5s
       timeout: 5s
       retries: 5
 
@@ -44,9 +44,22 @@ services:
       # check if server is up from within the container
       # (hence the localhost)
       test: curl --fail http://localhost:8000/api/alive/ || exit 1
-      interval: 1s
-      timeout: 5s
+      interval: 5s
+      timeout: 2s
       retries: 5
+
+
+  client:
+    container_name: fractal-client
+    depends_on:
+      server:
+        condition: service_healthy
+    image: fractal-client
+    build:
+      context: .
+      dockerfile: client/Dockerfile.client
+    ports:
+      - 5173:5173
 
   demos:
     container_name: fractal-demos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       # => errors if the server connects before the stop
       # this checks if the system is ready
       test: pg_isready -p 5433
-      interval: 5s
+      interval: 1s
       timeout: 5s
       retries: 5
 
@@ -44,18 +44,18 @@ services:
       # check if server is up from within the container
       # (hence the localhost)
       test: curl --fail http://localhost:8000/api/alive/ || exit 1
-      interval: 5s
-      timeout: 2s
+      interval: 1s
+      timeout: 5s
       retries: 5
 
-  client:
-    container_name: fractal-client
+  demos:
+    container_name: fractal-demos
     depends_on:
       server:
         condition: service_healthy
-    image: fractal-client
+    image: fractal-demos
     build:
       context: .
-      dockerfile: client/Dockerfile.client
-    ports:
-      - 5173:5173
+      dockerfile: demos/Dockerfile.demos
+    volumes:
+      - ./fractal-share/:/home/fractal-share/

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 run:
 	mkdir -p fractal-share/tasks fractal-share/data
-	docker compose up --build
+	docker compose up --build --force-recreate
 
 clean:
 	docker compose down

--- a/makefile
+++ b/makefile
@@ -2,6 +2,10 @@ run:
 	mkdir -p fractal-share/tasks fractal-share/data
 	docker compose up --build --force-recreate
 
+run-demos:
+	mkdir -p fractal-share/tasks fractal-share/data
+	docker compose up --build --force-recreate --file docker-compose-demos.yml
+
 clean:
 	docker compose down
 


### PR DESCRIPTION
Work in progress, but definitely worth exploring.

The `make run` in this branch runs example 01 from fractal-demos.
The idea would be that we can include a few more examples, and also produce a lightweight report about the formal status (did any step not go through?). This is not directly related to output validation, but we could also integrate it - at different levels.