### PR TITLE
Add Python 3.13 to `ubuntu24-slurm-multipy`

### DIFF
--- a/images/ubuntu24-slurm-multipy/Dockerfile
+++ b/images/ubuntu24-slurm-multipy/Dockerfile
@@ -8,7 +8,9 @@ RUN add-apt-repository ppa:deadsnakes/ppa
 
 # Install non-standard Python versions
 RUN apt install -y python3.11 python3.11-venv
+RUN apt install -y python3.13 python3.13-venv
 
 # Create a venv for each Python version
 RUN python3.11 -m venv /.venv3.11
 RUN python3.12 -m venv /.venv3.12
+RUN python3.13 -m venv /.venv3.13


### PR DESCRIPTION
closes #148 