### PR TITLE
Improve starting of slurmctld

### DIFF
--- a/images/ubuntu24-slurm/docker-entrypoint.sh
+++ b/images/ubuntu24-slurm/docker-entrypoint.sh
@@ -4,6 +4,7 @@
 export NODE_ADDR=127.0.0.1
 
 NODE="slurmnode1"
+SLURMDBD_PORT=6819
 
 echo "$NODE_ADDR   $NODE" >> /etc/hosts
 
@@ -23,9 +24,17 @@ service mariadb start
 service munge start
 service slurmdbd start
 
-while ! bash -c "</dev/tcp/127.0.0.1/6819" 2>/dev/null; do
-  echo "Waiting for port 6819 to be ready..."
+# checking slurmdbd port
+attempt=1
+max_seconds=10
+while ! timeout 1 bash -c "</dev/tcp/127.0.0.1/$SLURMDBD_PORT" 2>/dev/null; do
+  echo "Waiting for port $SLURMDBD_PORT to be ready..."
   sleep 1
+  attempt=$((attempt + 1))
+  if [ $attempt -gt $max_seconds ]; then
+    echo "Port $SLURMDBD_PORT not ready after $max_seconds seconds" >&2
+    exit 1
+  fi
 done
 
 service slurmctld start

--- a/images/ubuntu24-slurm/docker-entrypoint.sh
+++ b/images/ubuntu24-slurm/docker-entrypoint.sh
@@ -22,9 +22,27 @@ echo
 service mariadb start
 service munge start
 service slurmdbd start
+
+# slurmctld
+attempt=1
+max_seconds=10
 service slurmctld start
-service slurmctld stop
-service slurmctld start
+while [ "$attempt" -le $max_seconds ]; do
+  status=$(service slurmctld status 2>&1)
+  if [ -z "$status" ]; then
+    echo "[W] Empty response from \"slurmctld status\": trying to start slurmctld again..."
+    service slurmctld start
+  elif service slurmctld status 2>&1 | grep -q "running"; then
+    break
+  fi
+  sleep 1
+  attempt=$((attempt + 1))
+done
+if [ $attempt -ge $max_seconds ]; then
+  echo "slurmctld didn't reach running status after $max_seconds seconds" >&2
+  exit 1
+fi
+
 service slurmd start
 slurmd -N $NODE
 

--- a/images/ubuntu24-slurm/docker-entrypoint.sh
+++ b/images/ubuntu24-slurm/docker-entrypoint.sh
@@ -23,25 +23,12 @@ service mariadb start
 service munge start
 service slurmdbd start
 
-# slurmctld
-attempt=1
-max_seconds=10
-service slurmctld start
-while [ "$attempt" -le $max_seconds ]; do
-  status=$(service slurmctld status 2>&1)
-  if [ -z "$status" ]; then
-    echo "[W] Empty response from \"slurmctld status\": trying to start slurmctld again..."
-    service slurmctld start
-  elif service slurmctld status 2>&1 | grep -q "running"; then
-    break
-  fi
+while ! bash -c "</dev/tcp/127.0.0.1/6819" 2>/dev/null; do
+  echo "Waiting for port 6819 to be ready..."
   sleep 1
-  attempt=$((attempt + 1))
 done
-if [ $attempt -ge $max_seconds ]; then
-  echo "slurmctld didn't reach running status after $max_seconds seconds" >&2
-  exit 1
-fi
+
+service slurmctld start
 
 service slurmd start
 slurmd -N $NODE


### PR DESCRIPTION
I think that the following workaround introduced in #130 doesn't work well in all the situations:

```
service slurmctld start
service slurmctld stop
service slurmctld start
```

In my case the first command doesn't really start the service (I can wait forever and it never starts). I noticed that the status command returns an empty response instead of the expected "slurmctld is stopped". So I ended up in writing a loop that invoke `start` multiple times, until the `status` returns the expected value ("slurmctld (pid XXX) is running...").

For me this is working and there is no need to stop and restart the service again. Please confirm that this is working also on other machines.

I have the following output:

```
Starting SSH service

 * Starting OpenBSD Secure Shell server sshd                                                                                                                        [ OK ] 

Starting Slurm services (munge, slurmdbd, mariadb, slurmctld, slurmd)

 * Starting MariaDB database server mariadbd                                                                                                                        [ OK ] 
 * Starting MUNGE munged                                                                                                                                            [ OK ] 
 * Starting slurm-wlm database server interface                                                                                                                     [ OK ] 
 * Starting slurm central management daemon slurmctld                                                                                                               [ OK ] 
[W] Empty response from "slurmctld status": trying to start slurmctld again...
 * Starting slurm central management daemon slurmctld                                                                                                               [ OK ] 
[W] Empty response from "slurmctld status": trying to start slurmctld again...
 * Starting slurm central management daemon slurmctld                                                                                                               [ OK ] 
[W] Empty response from "slurmctld status": trying to start slurmctld again...
 * Starting slurm central management daemon slurmctld                                                                                                               [ OK ] 
 * Starting slurm compute node daemon slurmd                                                                                                                        [ OK ] 

squeue --version
slurm-wlm 23.11.4

sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
main*        up   infinite      1   idle slurmnode1
```
